### PR TITLE
@pedro zampier/feat add ajax to retrieve events by name

### DIFF
--- a/app/Controllers/EventsController.php
+++ b/app/Controllers/EventsController.php
@@ -141,4 +141,36 @@ class EventsController extends Controller
         FlashMessage::success('Evento removido com sucesso!');
         $this->redirectTo(route('events.index'));
     }
+
+    public function search(Request $request): void
+    {
+        $searchTerm = $request->getParam('q', '');
+
+        if (empty($searchTerm)) {
+            $events = $this->current_user->createdEvents()->get();
+        } else {
+            $events = Event::searchByName($searchTerm, $this->current_user->id);
+        }
+
+        if ($request->acceptJson()) {
+            header('Content-Type: application/json');
+            echo json_encode([
+                'success' => true,
+                'events' => array_map(function ($event) {
+                    return [
+                        'id' => $event->id,
+                        'name' => $event->name,
+                        'description' => $event->description,
+                        'start_date' => $event->start_date,
+                        'end_date' => $event->end_date,
+                        'event_location' => $event->event_location,
+                        'workload_hours' => $event->workload_hours,
+                        'event_type' => $event->event_type
+                    ];
+                }, $events)
+            ]);
+        } else {
+            $this->redirectTo(route('events.index'));
+        }
+    }
 }

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -77,4 +77,31 @@ class Event extends Model
     {
         return EventParticipant::exists(['event_id' => $this->id, 'participant_id' => $user->id]);
     }
+
+    public static function searchByName(string $searchTerm, int $ownerId): array
+    {
+        $pdo = \Core\Database\Database::getDatabaseConn();
+        $table = static::$table;
+        $attributes = implode(', ', static::$columns);
+
+        $sql = <<<SQL
+            SELECT id, {$attributes} FROM {$table}
+            WHERE owner_id = :owner_id
+            AND name LIKE :search_term
+            ORDER BY created_at DESC
+        SQL;
+
+        $stmt = $pdo->prepare($sql);
+        $stmt->bindValue(':owner_id', $ownerId);
+        $stmt->bindValue(':search_term', "%{$searchTerm}%");
+        $stmt->execute();
+
+        $rows = $stmt->fetchAll(\PDO::FETCH_ASSOC);
+
+        $models = [];
+        foreach ($rows as $row) {
+            $models[] = new static($row);
+        }
+        return $models;
+    }
 }

--- a/app/views/events/index.phtml
+++ b/app/views/events/index.phtml
@@ -5,7 +5,20 @@
         </h1>
     </header>
 
-    <div class="flex justify-end mb-8">
+    <div class="flex justify-between items-center mb-8">
+        <div class="flex-1 max-w-md">
+            <div class="relative">
+                <input
+                    type="text"
+                    id="event-search-input"
+                    placeholder="Buscar eventos..."
+                    class="w-full px-4 py-3 bg-[#0B1636] border border-[#2B6CE4] rounded-md text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-[#4A90E2]"
+                />
+                <div id="events-loading" class="hidden absolute right-3 top-3">
+                    <div class="animate-spin rounded-full h-6 w-6 border-b-2 border-[#4A90E2]"></div>
+                </div>
+            </div>
+        </div>
         <a href="<?= route('events.new') ?>" class="bg-[#2B6CE4] text-white px-6 py-3 rounded-md hover:bg-[#1F54C7] transition-colors font-medium inline-flex items-center gap-2">
             <i class="bi bi-plus"></i>
             Novo Evento
@@ -36,7 +49,7 @@
                         <th class="text-left py-4 px-6 text-[#4A90E2] font-semibold text-sm">Ações</th>
                     </tr>
                 </thead>
-                <tbody class="bg-[#0B1636] divide-y divide-[#14254E]">
+                <tbody id="events-results" class="bg-[#0B1636] divide-y divide-[#14254E]">
                     <?php foreach ($events as $event) : ?>
                         <tr class="hover:bg-[#14254E] transition-colors">
                             <td class="py-4 px-6">

--- a/config/routes.php
+++ b/config/routes.php
@@ -36,6 +36,7 @@ Route::middleware('auth')->group(function () {
     Route::delete('/logos/{id}', [LogosController::class, 'destroy'])->name('logos.destroy');
 
     Route::get('/events/new', [EventsController::class, 'new'])->name('events.new');
+    Route::get('/events/search', [EventsController::class, 'search'])->name('events.search');
     Route::get('/events/all', [EventParticipantsController::class, 'index'])
         ->name('event.participants');
     Route::get('/events/all/page/{page}', [EventParticipantsController::class, 'index'])

--- a/public/assets/js/application.js
+++ b/public/assets/js/application.js
@@ -1,26 +1,198 @@
+const Ajax = {
+  async get(url) {
+    try {
+      const response = await fetch(url, {
+        method: 'GET',
+        headers: {
+          'Accept': 'application/json',
+          'X-Requested-With': 'XMLHttpRequest'
+        },
+        credentials: 'same-origin'
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+
+      const contentType = response.headers.get('content-type');
+      if (contentType && contentType.includes('application/json')) {
+        return await response.json();
+      }
+
+      return { success: true };
+    } catch (error) {
+      console.error('AJAX Error:', error);
+      throw error;
+    }
+  }
+};
+
+const Toast = {
+  show(message, type = 'success') {
+    const container = this.getContainer();
+    const toast = document.createElement('div');
+
+    const bgColor = type === 'success' ? 'bg-green-500' : 'bg-red-500';
+    const icon = type === 'success' ? '✓' : '✕';
+
+    toast.className = 'transform transition-all duration-300 translate-x-full';
+    toast.innerHTML = `
+      <div class="${bgColor} text-white px-6 py-4 rounded-lg shadow-lg flex items-center space-x-3 min-w-[300px]">
+        <span class="text-2xl">${icon}</span>
+        <span class="flex-1">${message}</span>
+        <button class="toast-close ml-2 text-white hover:text-gray-200 font-bold">×</button>
+      </div>
+    `;
+
+    container.appendChild(toast);
+
+    setTimeout(() => toast.classList.remove('translate-x-full'), 10);
+
+    toast.querySelector('.toast-close').addEventListener('click', () => {
+      toast.classList.add('translate-x-full');
+      setTimeout(() => toast.remove(), 300);
+    });
+
+    setTimeout(() => {
+      toast.classList.add('translate-x-full');
+      setTimeout(() => toast.remove(), 300);
+    }, 4000);
+  },
+
+  getContainer() {
+    let container = document.getElementById('toast-container');
+    if (!container) {
+      container = document.createElement('div');
+      container.id = 'toast-container';
+      container.className = 'fixed top-4 right-4 z-50 space-y-2';
+      document.body.appendChild(container);
+    }
+    return container;
+  }
+};
+
+async function searchEvents(searchTerm) {
+  const resultsContainer = document.getElementById('events-results');
+  const loadingIndicator = document.getElementById('events-loading');
+
+  if (!resultsContainer) {
+    return;
+  }
+
+  if (loadingIndicator) {
+    loadingIndicator.classList.remove('hidden');
+  }
+
+  try {
+    const response = await Ajax.get(`/events/search?q=${encodeURIComponent(searchTerm)}`);
+
+    if (response.success) {
+      renderEvents(response.events);
+    } else {
+      Toast.show('Erro ao buscar eventos', 'error');
+    }
+  } catch (error) {
+    Toast.show('Erro ao buscar eventos', 'error');
+    console.error(error);
+  } finally {
+    if (loadingIndicator) {
+      loadingIndicator.classList.add('hidden');
+    }
+  }
+}
+
+function renderEvents(events) {
+  const resultsContainer = document.getElementById('events-results');
+
+  if (!resultsContainer) {
+    return;
+  }
+
+  if (events.length === 0) {
+    resultsContainer.innerHTML = `
+      <tr>
+        <td colspan="8" class="px-6 py-4 text-center text-white">
+          Nenhum evento encontrado
+        </td>
+      </tr>
+    `;
+    return;
+  }
+
+  resultsContainer.innerHTML = events.map(event => {
+    const startDate = event.start_date ? new Date(event.start_date).toLocaleDateString('pt-BR') : '-';
+    return `
+    <tr class="hover:bg-[#14254E] transition-colors">
+      <td class="py-4 px-6">
+        <a href="/events/${event.id}" class="text-[#4A90E2] hover:text-[#2B6CE4] hover:underline">
+          #${event.id}
+        </a>
+      </td>
+      <td class="py-4 px-6 text-white font-medium">${event.name}</td>
+      <td class="py-4 px-6 text-white">${event.event_type || '-'}</td>
+      <td class="py-4 px-6 text-white">${startDate}</td>
+      <td class="py-4 px-6 text-white">${event.workload_hours ? event.workload_hours + 'h' : '-'}</td>
+      <td class="py-4 px-6 text-white">-</td>
+      <td class="py-4 px-6">
+        <span class="bg-green-600 text-white px-3 py-1 rounded-full text-xs font-medium">Ativo</span>
+      </td>
+      <td class="py-4 px-6">
+        <div class="flex justify-end gap-2">
+          <a href="/events/${event.id}" class="text-[#4A90E2] hover:text-[#2B6CE4] p-2 rounded transition-colors" title="Visualizar">
+            <i class="bi bi-eye text-lg"></i>
+          </a>
+          <a href="/events/${event.id}/participants" class="text-green-500 hover:text-green-400 p-2 rounded transition-colors" title="Gerenciar Participantes">
+            <i class="bi bi-people text-lg"></i>
+          </a>
+          <a href="/events/${event.id}/edit" class="text-[#4A90E2] hover:text-[#2B6CE4] p-2 rounded transition-colors" title="Editar">
+            <i class="bi bi-pencil-square text-lg"></i>
+          </a>
+        </div>
+      </td>
+    </tr>
+  `;
+  }).join('');
+}
+
 document.addEventListener("DOMContentLoaded", function () {
+
   const imagePreviewInput = document.getElementById("image_preview_input");
   const preview = document.getElementById("image_preview");
   const imagePreviewSubmit = document.getElementById("image_preview_submit");
 
-  if (!(imagePreviewInput && preview)) return;
+  if (imagePreviewInput && preview) {
+    imagePreviewInput.style.display = "none";
+    imagePreviewSubmit.style.display = "none";
 
-  imagePreviewInput.style.display = "none";
-  imagePreviewSubmit.style.display = "none";
+    preview.addEventListener("click", function () {
+      imagePreviewInput.click();
+    });
 
-  preview.addEventListener("click", function () {
-    imagePreviewInput.click();
-  });
+    imagePreviewInput.addEventListener("change", function (event) {
+      const file = event.target.files[0];
+      if (file) {
+        const reader = new FileReader();
+        reader.onload = function (e) {
+          document.getElementById("image_preview").src = e.target.result;
+          imagePreviewSubmit.style.display = "block";
+        };
+        reader.readAsDataURL(file);
+      }
+    });
+  }
 
-  imagePreviewInput.addEventListener("change", function (event) {
-    const file = event.target.files[0];
-    if (file) {
-      const reader = new FileReader();
-      reader.onload = function (e) {
-        document.getElementById("image_preview").src = e.target.result;
-        imagePreviewSubmit.style.display = "block";
-      };
-      reader.readAsDataURL(file);
-    }
-  });
+  const searchInput = document.getElementById('event-search-input');
+  if (searchInput) {
+    let searchTimeout;
+
+    searchInput.addEventListener('input', (e) => {
+      clearTimeout(searchTimeout);
+      const searchTerm = e.target.value.trim();
+
+      searchTimeout = setTimeout(() => {
+        searchEvents(searchTerm);
+      }, 300);
+    });
+  }
+
 });

--- a/tests/Acceptance/Events/EventSearchAjaxCest.php
+++ b/tests/Acceptance/Events/EventSearchAjaxCest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Tests\Acceptance\Events;
+
+use App\Models\Event;
+use App\Models\User;
+use Tests\Acceptance\BaseAcceptanceCest;
+use Tests\Support\AcceptanceTester;
+
+class EventSearchAjaxCest extends BaseAcceptanceCest
+{
+    // Teste 1: Busca de eventos via Ajax retorna resultados corretos
+    public function buscaDeEventosViaAjaxRetornaResultados(AcceptanceTester $page): void
+    {
+        $criador = $this->criarCriador();
+
+        $page->login($criador->email, '123456');
+
+        $event1 = $this->criarEvento($criador->id, 'Workshop de PHP', 'workshop');
+        $event2 = $this->criarEvento($criador->id, 'Curso de Laravel', 'curso');
+        $event3 = $this->criarEvento($criador->id, 'Palestra sobre Python', 'palestra');
+
+        $page->amOnPage('/events');
+        $page->wait(1);
+
+        $page->seeElement('#event-search-input');
+
+        $page->fillField('#event-search-input', 'PHP');
+        $page->wait(2);
+
+        $page->see('Workshop de PHP');
+        $page->dontSee('Curso de Laravel');
+        $page->dontSee('Palestra sobre Python');
+
+        $page->fillField('#event-search-input', 'Curso');
+        $page->wait(2);
+
+        $page->see('Curso de Laravel');
+        $page->dontSee('Workshop de PHP');
+        $page->dontSee('Palestra sobre Python');
+    }
+
+    // Teste 2: Busca de eventos via Ajax sem resultados
+    public function buscaDeEventosViaAjaxSemResultados(AcceptanceTester $page): void
+    {
+        $criador = $this->criarCriador();
+        $page->login($criador->email, '123456');
+
+        $this->criarEvento($criador->id, 'Workshop de PHP', 'workshop');
+
+        $page->amOnPage('/events');
+        $page->wait(1);
+
+        $page->see('Workshop de PHP');
+
+        $page->fillField('#event-search-input', 'JavaScript');
+        $page->wait(1);
+
+        $page->see('Nenhum evento encontrado');
+        $page->dontSee('Workshop de PHP');
+
+        $page->fillField('#event-search-input', ' ');
+        $page->wait(1);
+
+        $page->see('Workshop de PHP');
+    }
+
+    private function criarCriador(): User
+    {
+        $criador = new User([
+            'name' => 'Criador de Eventos',
+            'email' => 'criador@smartcert.com',
+            'password' => '123456',
+            'password_confirmation' => '123456',
+            'cpf' => '12345678901'
+        ]);
+        $criador->is_admin = true;
+        $criador->save();
+
+        return $criador;
+    }
+
+    private function criarEvento(int $criadorId, string $nome, string $tipo): Event
+    {
+        $event = new Event([
+            'name' => $nome,
+            'description' => "Descrição do evento {$nome}",
+            'start_date' => date('Y-m-d'),
+            'end_date' => date('Y-m-d', strtotime('+1 day')),
+            'event_location' => 'São Paulo',
+            'workload_hours' => 8,
+            'event_type' => $tipo,
+            'creator_id' => $criadorId,
+            'owner_id' => $criadorId,
+            'is_active' => true,
+            'created_at' => date('Y-m-d H:i:s'),
+            'updated_at' => date('Y-m-d H:i:s')
+        ]);
+
+        $saved = $event->save();
+
+        return $event;
+    }
+}


### PR DESCRIPTION

Esta pull request adiciona uma nova funcionalidade de busca de eventos baseada em AJAX à página de eventos, permitindo que os usuários pesquisem seus eventos por nome em tempo real. A implementação inclui suporte backend para pesquisa, melhorias na interface frontend, lógica JavaScript para manipulação de requisições AJAX e renderização de resultados, além de novos testes de aceitação para garantir o comportamento correto.

**Funcionalidade Backend:**
* Adicionado novo método `search` ao `EventsController` que trata requisições AJAX de busca de eventos e retorna resultados como JSON, revertendo para todos os eventos caso nenhum termo de busca seja fornecido.
* Implementado método estático `Event::searchByName` para consultar eventos por nome de um proprietário específico, suportando correspondências parciais e ordenação por data de criação.
* Registrada nova rota `/events/search` mapeada para o método de busca do controller para requisições AJAX.

**Interface e Lógica Frontend:**
* Atualizado `events/index.phtml` para incluir campo de busca com indicador de carregamento e ajustada marcação da tabela para renderização dinâmica de resultados. [[1]](diffhunk://#diff-1bf2fd7e7b4dfd7f657af08756a6c0b1aae945cbd9969c009ba5704b839869b8L8-R21) [[2]](diffhunk://#diff-1bf2fd7e7b4dfd7f657af08756a6c0b1aae945cbd9969c009ba5704b839869b8L39-R52)
* Adicionado JavaScript abrangente em `application.js` para busca AJAX de eventos, renderização de resultados, notificações toast para erros e manipulação de entrada com debounce para experiência de usuário fluida. [[1]](diffhunk://#diff-5bc80dd86fd153837dedf119b2d0dc1f625b84f7440dc20ac7551f4e8c7f7354R1-R163) [[2]](diffhunk://#diff-5bc80dd86fd153837dedf119b2d0dc1f625b84f7440dc20ac7551f4e8c7f7354R182-R197)

**Testes:**
* Adicionados testes de aceitação em `EventSearchAjaxCest.php` para verificar o comportamento correto da busca AJAX, incluindo casos com resultados e sem resultados.